### PR TITLE
Clarify moving to next section of a lab

### DIFF
--- a/bin/html/index.html
+++ b/bin/html/index.html
@@ -188,7 +188,7 @@ body {
             <a target="_blank" href="https://rosettacode.org/wiki/Category:J#mw-pages">Rosetta Code</a>
           </div>
         </div>        
-        <input type="button" value="Advance Lab" style="display:none" id="advanceLab" title="hotkey: ctrl+>">        
+        <input type="button" value="Advance lab" style="display:none" id="advanceLab" title="hotkey: ctrl+>">        
         <span id="permalink" style="display:none">
           <a id="permalinkBase" href="#">editor permalink</a>
         </span>

--- a/bin/html2/tbar.js
+++ b/bin/html2/tbar.js
@@ -86,7 +86,7 @@ function inittbar() {
  h += "</ul></li>"
 
  h += top("Labs", 1);
- h += sub2("advlab", "Advance Labs", "Shift+Ctrl+>", 1);
+ h += sub2("advlab", "Advance current lab", "Shift+Ctrl+>", 1);
  for (var i = 0; i < labs.length; i++)
   h += sub1("lab" + i, titles[i]);
  h += "</ul></li>"

--- a/labs_labs/labintro.txt
+++ b/labs_labs/labintro.txt
@@ -9,8 +9,8 @@ A section starts with comments (such as these), optionally
 followed by J sentences which are automatically executed in
 the J session.
 
-Select menu Studio|Advance, or use the corresponding shortcut
-key, to advance to the next section.
+Select menu Labs|'Advance current lab', or use the corresponding
+shortcut key, to advance to the next section.
 )
 i.5         NB. automatically executed
 +/\i.5      NB. automatically executed


### PR DESCRIPTION
The current live site says:

    To advance the lab, select menu Help|Studio|Advance or the
    corresponding shortcut.

but the command is actually: `Labs|Advance Labs`.

The message in Git is currently still wrong:

    Select menu Studio|Advance, or use the corresponding shortcut key,
    to advance to the next section.

The menu is still: `Labs|Advance Labs`.

I found the phrase "Advance Labs" confusing, for the following (subjective) reasons:

  1) It reads too easily as "Advanced Labs", possibly implying a submenu for
     advanced topics.

  2) It is plural, when it only applies to the current singular lab,
     reinforcing the misreading as "Advanced Labs".

  3) The "Labs" being captitalised also adds to the sense of referring
     to a different lab.