### PR TITLE
Use base64 permalink, still support old links

### DIFF
--- a/bin/html2/localj.js
+++ b/bin/html2/localj.js
@@ -44,16 +44,20 @@ var localjserver = {
 }
 
 function genPermalink() {
-  document.getElementById("mn_plink").childNodes[0].href = '#code='+encodeURIComponent(ecmget())
-    //replace parentheses as they cause problems in markdown
-    .replace(/\(/g, '%28').replace(/\)/g, '%29');;
+  let bytes = new TextEncoder("utf-8").encode(ecmget());
+  let base64 = btoa(String.fromCodePoint(...bytes));
+  document.getElementById("mn_plink").childNodes[0].href = '#base64=' + base64;
 }
 
 function checkPermalink() {
   var code = decodeURIComponent(window.location.hash).substr(1);
-  if (code.substring(0,5)=='code=') {
-    code = code.substring(5);
-    ecmset(code);
+  if (code.substring(0,7) == 'base64=') {
+    let base64 = code.substr(7);
+    let arr = Uint8Array.from(atob(base64), (b) => b.codePointAt(0));
+    ecmset(new TextDecoder("utf-8").decode(arr));
+  }
+  else if (code.substring(0,5) == 'code=') {
+    ecmset(code.substring(5));
   }
   else if (code.toLowerCase().substring(0,4) == 'url=') {
       let url = code.substring(4);


### PR DESCRIPTION
Changes the permalink created by `genPermalink` to encode the data in base64. Add a branch to `checkPermalink` to decode base64 links. Old URI encoded links still work.